### PR TITLE
remove BouncyCastle.Cryptography nuget fix from proton-cs-client library

### DIFF
--- a/source/proton-cs-client/proton-cs-client.csproj
+++ b/source/proton-cs-client/proton-cs-client.csproj
@@ -20,13 +20,4 @@
     <ProjectReference Include="..\..\gitmodules\TuviAuthProtonLib\source\TuviAuthProtonLib\TuviAuthProtonLib.csproj" />
   </ItemGroup>
 
-  <!-- In current version of BouncyCastle.Cryptography there is a problem with finding interfaces implementations. 
-  So as temporarily solution we use next insertion taken from https://github.com/bcgit/bc-csharp/issues/447 -->
-  <ItemGroup>
-    <PackageReference Include="BouncyCastle.Cryptography" Version="2.2.1" ExcludeAssets="Compile" GeneratePathProperty="true" />
-    <Reference Include="BouncyCastle.Cryptography">
-      <HintPath>$(PkgBouncyCastle_Cryptography)\lib\netstandard2.0\BouncyCastle.Cryptography.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
The **BouncyCastle.Cryptography** nuget fix must be applied to the application project (not library)